### PR TITLE
챗봇의 역할 목록을 조회하는 API 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule } from '@nestjs/config';
 import { OpenaiClientModule } from './openai-client/openai-client.module';
 import { ChatsModule } from './chats/chats.module';
 import { MongooseModule } from '@nestjs/mongoose';
+import { ChatbotsModule } from './chatbots/chatbots.module';
 import * as process from 'process';
 
 @Module({
@@ -13,6 +14,7 @@ import * as process from 'process';
     MongooseModule.forRoot(process.env.MONGO_DB_URL),
     OpenaiClientModule,
     ChatsModule,
+    ChatbotsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/chatbots/chatbots.controller.spec.ts
+++ b/src/chatbots/chatbots.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatbotsController } from './chatbots.controller';
+
+describe('ChatbotsController', () => {
+  let controller: ChatbotsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChatbotsController],
+    }).compile();
+
+    controller = module.get<ChatbotsController>(ChatbotsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/chatbots/chatbots.controller.ts
+++ b/src/chatbots/chatbots.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get } from '@nestjs/common';
+import { ChatbotsService } from './chatbots.service';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { GetChatbotRolesSwagger } from './dto/get-chatbot-roles.swagger';
+
+@ApiTags('Chatbots')
+@Controller('api/chatbots')
+export class ChatbotsController {
+  constructor(private readonly chatbotsService: ChatbotsService) {}
+
+  @Get('roles')
+  @ApiOperation({ summary: '챗봇의 역할 목록을 조회' })
+  @ApiOkResponse({
+    description: '챗봇의 역할 목록',
+    type: GetChatbotRolesSwagger,
+  })
+  async getChatbotRoles() {
+    return await this.chatbotsService.getChatbotRoles();
+  }
+}

--- a/src/chatbots/chatbots.module.ts
+++ b/src/chatbots/chatbots.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ChatbotsController } from './chatbots.controller';
+import { ChatbotsService } from './chatbots.service';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Chatbot, ChatbotSchema } from '../schemas/chatbot.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Chatbot.name, schema: ChatbotSchema }]),
+  ],
+  controllers: [ChatbotsController],
+  providers: [ChatbotsService],
+})
+export class ChatbotsModule {}

--- a/src/chatbots/chatbots.service.spec.ts
+++ b/src/chatbots/chatbots.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatbotsService } from './chatbots.service';
+
+describe('ChatbotsService', () => {
+  let service: ChatbotsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ChatbotsService],
+    }).compile();
+
+    service = module.get<ChatbotsService>(ChatbotsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/chatbots/chatbots.service.ts
+++ b/src/chatbots/chatbots.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Chatbot } from '../schemas/chatbot.schema';
+import { Model } from 'mongoose';
+
+@Injectable()
+export class ChatbotsService {
+  constructor(
+    @InjectModel(Chatbot.name) private readonly chatbotModel: Model<Chatbot>,
+  ) {}
+
+  async getChatbotRoles(): Promise<string[]> {
+    const chatbots = await this.chatbotModel.find();
+
+    return chatbots.map((chatbot): string => chatbot.role);
+  }
+}

--- a/src/chatbots/dto/get-chatbot-roles.swagger.ts
+++ b/src/chatbots/dto/get-chatbot-roles.swagger.ts
@@ -1,0 +1,12 @@
+import { BaseResponseSwagger } from '../../common/swagger/base-response.swagger';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetChatbotRolesSwagger implements BaseResponseSwagger {
+  @ApiProperty({
+    required: true,
+    example: ['lawyer'],
+    type: [String],
+    description: '챗봇의 역할 목록',
+  })
+  data: string[];
+}


### PR DESCRIPTION
- 챗봇의 역할 목록을 조회하는 API 추가 : `GET /api/chatbots/roles`

## 관련 이슈
- #4 