### PR TITLE
cosmosDB에서 발생하는 orderBy 버그 해결

### DIFF
--- a/src/entities/logging.ts
+++ b/src/entities/logging.ts
@@ -15,4 +15,5 @@ export class Logging {
 // 위의 작성한 클래스를 바탕으로 Mongoose에서 사용하는 스키마 클래스를 만들어준다.
 const schema = SchemaFactory.createForClass(Logging);
 schema.plugin(mongoosePaginate);
+schema.index({ timestamp: -1 });
 export const LoggingSchema = schema;


### PR DESCRIPTION
놀랍게도 cosmosDB에서는 orderBy를 건 필드에 인덱스가 안 걸려있으면 에러가 발생한다. 성능 때문에 그런 것 같은데, 이를 해결하기 위해 인덱스 적용